### PR TITLE
Bug/ca units wrong

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,8 +102,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         missingDimensionStrategy "RNN.reactNativeVersion", "reactNative57_5"
-        versionCode 3
-        versionName "1.0.2"
+        versionCode 4
+        versionName "1.0.3"
     }
     splits {
         abi {

--- a/ios/Breeze/Info.plist
+++ b/ios/Breeze/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Breeze",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/src/common/locations/locations.thunks.js
+++ b/src/common/locations/locations.thunks.js
@@ -55,7 +55,12 @@ export const setLocationAndFetchWeather = location => (dispatch) => {
 export const lookupLocationAndFetchWeather = (placeID, sessionToken) => (dispatch) => {
   getLocationByPlaceID(placeID, sessionToken)
     .then((location) => {
-      dispatch(setLocation(location));
+      const countryCode = getCountryFromLocation(location);
+      const locationPlus = {
+        ...location,
+        countryCode,
+      };
+      dispatch(setLocation(locationPlus));
       dispatch(setIsCurrentLocation(false));
       dispatch(setCoords({
         latitude: location.geometry.location.lat,

--- a/src/common/locations/locations.thunks.js
+++ b/src/common/locations/locations.thunks.js
@@ -2,6 +2,7 @@ import {
   getCurrentPosition,
   getLocationByLatLong,
   getLocationByPlaceID,
+  getCountryFromLocation,
 } from '../../services/geocode';
 import { getWeather } from '../../services/weather';
 import {
@@ -15,7 +16,7 @@ import {
 
 export const fetchAndSetWeather = () => (dispatch, getState) => {
   const { locations, settings } = getState();
-  getWeather(locations[0].coords, settings.units)
+  getWeather(locations[0].coords, settings.units, locations[0].location)
     .then((weather) => {
       dispatch(setWeather(weather));
     })
@@ -29,14 +30,21 @@ export const fetchAndSetLocation = () => (dispatch, getState) => {
   // Reverse geocode address from coords
   getLocationByLatLong(coords)
     .then((location) => {
-      dispatch(setLocation(location));
+      const countryCode = getCountryFromLocation(location);
+      const locationPlus = {
+        ...location,
+        countryCode,
+      };
+      dispatch(setLocation(locationPlus));
+    })
+    .finally(() => {
+      dispatch(fetchAndSetWeather());
     });
 };
 
 export const setCoordsAndFetchLocation = coords => (dispatch) => {
   dispatch(setCoords(coords));
   dispatch(fetchAndSetLocation());
-  dispatch(fetchAndSetWeather());
 };
 
 export const setLocationAndFetchWeather = location => (dispatch) => {
@@ -78,7 +86,6 @@ export const fetchAndSetUserCoords = () => (dispatch, getState) => {
       }
     })
     .finally(() => {
-      dispatch(fetchAndSetWeather());
       dispatch(fetchAndSetLocation());
     });
 };

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -13,7 +13,7 @@ const About = () => (
       }}
       style={{ width: 96, height: 98 }}
     />
-    <LScript opacity={0.8} fontSize={0} textKey="settings:version" textAlign="center" mt={4} interpolation={{ version: '1.0.2' }} />
+    <LScript opacity={0.8} fontSize={0} textKey="settings:version" textAlign="center" mt={4} interpolation={{ version: '1.0.3' }} />
     <LScript opacity={0.8} fontSize={0} textKey="settings:copyright" textAlign="center" />
     <LScript opacity={0.8} fontSize={0} textKey="settings:buildLocation" textAlign="center" />
   </Box>

--- a/src/services/geocode.js
+++ b/src/services/geocode.js
@@ -15,6 +15,13 @@ const geolocate = (args = {}) => new Promise((resolve, reject) => {
   );
 });
 
+export const getCountryFromLocation = (location) => {
+  const countryComponents = location.address_components.filter(
+    addressComponent => addressComponent.types.includes('country'),
+  );
+  return countryComponents.length === 0 ? undefined : countryComponents[0].short_name;
+};
+
 const preferLocality = (a, b) => {
   if (a.types.includes('locality') && !b.types.includes('locality')) {
     return -1;

--- a/src/services/weather.js
+++ b/src/services/weather.js
@@ -1,7 +1,7 @@
 import { DARK_SKY_SECRET_KEY } from 'react-native-dotenv';
 // import samplePayload from './sample-payload.json';
 
-export const getWeather = ({ latitude, longitude }, units = 'auto') => {
+export const getWeather = ({ latitude, longitude }, units = 'auto', location = {}) => {
   // if (__DEV__) {
   //   return new Promise((resolve) => {
   //     setTimeout(() => {
@@ -10,7 +10,13 @@ export const getWeather = ({ latitude, longitude }, units = 'auto') => {
   //   });
   // }
 
-  const url = `https://api.darksky.net/forecast/${DARK_SKY_SECRET_KEY}/${latitude},${longitude}?units=${units}`;
+  // Country code of 'ca' is returning incorrect weather. Use 'si' instead
+  let safeUnits = units;
+  if (units === 'auto' && location && location.countryCode === 'CA') {
+    safeUnits = 'si';
+  }
+
+  const url = `https://api.darksky.net/forecast/${DARK_SKY_SECRET_KEY}/${latitude},${longitude}?units=${safeUnits}`;
   return fetch(url, { cache: 'no-store' })
     .then(response => response.json());
 };


### PR DESCRIPTION
Workaround for a bug with the Dark Sky API. If the user had their units set to "auto" and makes a request for a Canadian city, then the API was returning incorrect weather (often "Dangerously Windy).

The workaround is to check what the user's country is. If the user's country is "CA" and their units are set to "auto", then we will use metric system instead of "auto" for units.